### PR TITLE
Creates new seed data to speed up manual testing

### DIFF
--- a/data/seeds/001_Parents.js
+++ b/data/seeds/001_Parents.js
@@ -3,7 +3,7 @@ const bc = require('bcryptjs');
 
 const parents = [...new Array(4)].map((i, idx) => ({
   Name: `${faker.name.firstName()} ${faker.name.lastName()}`,
-  PIN: `${bc.hashSync(`000${idx}`, process.env.BCRYPT_ROUNDS || 6)}`,
+  PIN: `${bc.hashSync(`0000`, process.env.BCRYPT_ROUNDS || 6)}`,
   Email: `llama00${idx + 1}@maildrop.cc`,
 }));
 

--- a/data/seeds/002_Avatars.js
+++ b/data/seeds/002_Avatars.js
@@ -1,17 +1,3 @@
-// const faker = require('faker');
-
-// const avatars = [...new Array(10)].map(() => ({
-//   AvatarURL: faker.image.avatar(),
-// }));
-
-// exports.seed = function (knex) {
-//   // Inserts seed entries
-//   return knex('Avatars').insert(avatars);
-// };
-
-
-
-
 exports.seed = function(knex) {
 
   return knex('Avatars').insert([

--- a/data/seeds/006_Children.js
+++ b/data/seeds/006_Children.js
@@ -1,10 +1,10 @@
 const faker = require('faker');
 const bc = require('bcryptjs');
 
-const children = [...new Array(8)].map((i, idx) => ({
+const children = [...new Array(16)].map((i, idx) => ({
   Name: `${faker.name.firstName()}`,
-  PIN: `${bc.hashSync(`000${idx}`, process.env.BCRYPT_ROUNDS || 6)}`,
-  ParentID: `${Math.floor((idx + 2) / 2)}`,
+  PIN: `${bc.hashSync(`0000`, process.env.BCRYPT_ROUNDS || 6)}`,
+  ParentID: `${Math.floor((idx + 4) / 4)}`,
   AvatarID: `${faker.random.number({ min: 1, max: 8 })}`,
   GradeLevelID: `${faker.random.number({ min: 1, max: 6 })}`,
   CohortID: 1,

--- a/data/seeds/007_Submissions.js
+++ b/data/seeds/007_Submissions.js
@@ -1,0 +1,17 @@
+const fake = require('faker');
+
+const submissions = [...new Array(16)].map((i, idx) => ({
+  ChildID: `${idx + 1}`,
+  StoryID: 1,
+  HasRead: true,
+  HasWritten: true,
+  HasDrawn: true,
+  Complexity: 30,
+  LowConfidence: false,
+  Status: 'APPROVED'
+}));
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Submissions').insert(submissions);
+};

--- a/data/seeds/007_Submissions.js
+++ b/data/seeds/007_Submissions.js
@@ -1,5 +1,3 @@
-const fake = require('faker');
-
 const submissions = [...new Array(16)].map((i, idx) => ({
   ChildID: `${idx + 1}`,
   StoryID: 1,

--- a/data/seeds/008_Writings_Drawings.js
+++ b/data/seeds/008_Writings_Drawings.js
@@ -1,0 +1,20 @@
+const faker = require('faker');
+
+const writings = [...new Array(16)].map((i, idx) => ({
+  URL: `https://picsum.photos/id/${idx + 1}/400`,
+  PageNum: 0,
+  SubmissionID: `${idx + 1}`
+}));
+
+const drawings = [...new Array(16)].map((i, idx) => ({
+  URL: `https://picsum.photos/id/${idx + 1}/400`,
+  SubmissionID: `${idx + 1}`
+}));
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Writing').insert(writings)
+  .then(() => {
+    return knex('Drawing').insert(drawings);
+  });
+};

--- a/data/seeds/009_Squads.js
+++ b/data/seeds/009_Squads.js
@@ -1,0 +1,9 @@
+const squads = [...new Array(4)].map((i, idx) => ({
+  CohortID: 1,
+  Winner: null
+}));
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Squads').insert(squads);
+};

--- a/data/seeds/010_Teams.js
+++ b/data/seeds/010_Teams.js
@@ -1,0 +1,15 @@
+const teams = [
+  { Num: 1, Name: 'Team 1', SquadID: 1, Points: null},
+  { Num: 2, Name: 'Team 2', SquadID: 1, Points: null},
+  { Num: 1, Name: 'Team 1', SquadID: 2, Points: null},
+  { Num: 2, Name: 'Team 2', SquadID: 2, Points: null},
+  { Num: 1, Name: 'Team 1', SquadID: 3, Points: null},
+  { Num: 2, Name: 'Team 2', SquadID: 3, Points: null},
+  { Num: 1, Name: 'Team 1', SquadID: 4, Points: null},
+  { Num: 2, Name: 'Team 2', SquadID: 4, Points: null}
+]
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Teams').insert(teams);
+};

--- a/data/seeds/011_Members.js
+++ b/data/seeds/011_Members.js
@@ -1,0 +1,9 @@
+const members = [...new Array(16)].map((i, idx) => ({
+  TeamID: `${Math.floor((idx + 2) / 2)}`,
+  SubmissionID: `${idx + 1}`
+}));
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Members').insert(members);
+};

--- a/data/seeds/012_Points.js
+++ b/data/seeds/012_Points.js
@@ -1,0 +1,11 @@
+const points = [...new Array(16)].map((i, idx) => ({
+  WritingPoints: Math.floor(Math.random() * 100),
+  DrawingPoints: Math.floor(Math.random() * 100),
+  MemberID: `${Math.floor((idx + 2) / 2)}`,
+  SubmissionID: `${idx + 1}`
+}));
+
+exports.seed = function(knex) {
+  // Inserts seed entries
+  return knex('Points').insert(points);
+};


### PR DESCRIPTION
# Description

Manual testing required going back-and-forth between the child dashboard and the moderation panel. In order to test the match up logic more easily, this pull request creates seed data for the following tables:
- Submissions
- Writings
- Drawings
- Squads
- Teams
- Members
- Points

Now, all you have to do is go to the moderation panel, click **Generate Faceoffs** and head straight to the match up screen.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes (manually)
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
