### PR TITLE
Fixes fake point sharing to total to 400 per squad

### DIFF
--- a/data/seeds/012_Points.js
+++ b/data/seeds/012_Points.js
@@ -1,9 +1,21 @@
-const points = [...new Array(8)].map((i, idx) => ({
-  WritingPoints: 30,
-  DrawingPoints: 20,
-  MemberID: `${Math.floor((idx + 2) / 2)}`,
-  SubmissionID: `${idx + 1}`,
-}));
+const points = [
+  { WritingPoints: 50, DrawingPoints: 15, MemberID: 1, SubmissionID: 1 },
+  { WritingPoints: 25, DrawingPoints: 10, MemberID: 1, SubmissionID: 2 },
+  { WritingPoints: 30, DrawingPoints: 30, MemberID: 2, SubmissionID: 1 },
+  { WritingPoints: 10, DrawingPoints: 30, MemberID: 2, SubmissionID: 2 },
+  { WritingPoints: 40, DrawingPoints: 20, MemberID: 3, SubmissionID: 3 },
+  { WritingPoints: 20, DrawingPoints: 20, MemberID: 3, SubmissionID: 4 },
+  { WritingPoints: 50, DrawingPoints: 20, MemberID: 4, SubmissionID: 3 },
+  { WritingPoints: 10, DrawingPoints: 20, MemberID: 4, SubmissionID: 4 },
+  { WritingPoints: 50, DrawingPoints: 15, MemberID: 5, SubmissionID: 5 },
+  { WritingPoints: 25, DrawingPoints: 10, MemberID: 5, SubmissionID: 6 },
+  { WritingPoints: 30, DrawingPoints: 30, MemberID: 6, SubmissionID: 5 },
+  { WritingPoints: 10, DrawingPoints: 30, MemberID: 6, SubmissionID: 6 },
+  { WritingPoints: 40, DrawingPoints: 20, MemberID: 7, SubmissionID: 7 },
+  { WritingPoints: 20, DrawingPoints: 20, MemberID: 7, SubmissionID: 8 },
+  { WritingPoints: 50, DrawingPoints: 20, MemberID: 8, SubmissionID: 7 },
+  { WritingPoints: 10, DrawingPoints: 20, MemberID: 8, SubmissionID: 8 },
+];
 
 exports.seed = function (knex) {
   // Inserts seed entries


### PR DESCRIPTION
# Description

The previous **_Points_** seed data wasn't totaling up to 400 points in the Match Up screen.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
